### PR TITLE
Update checkout+setup actions to latest versions and add inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Shared Github Actions for ioBroker testing workflows: Adapter tests
 | `build`           | Set to `'true'` when the adapter needs a build step before testing                                                                                                                                   | ❌        |     `'false'`     |
 | `build-command`   | Overwrite the default build command                                                                                                                                                                  | ❌        | `'npm run build'` |
 | `extra-tests`     | Add an additional command to run before ioBroker's tests                                                                                                                                             | ❌        |         -         |
+| `unit-test-command`   | Overwrite the default unit test command                                                                                                                                                                  | ❌        | `'npm run test:unit'` |
+| `integration-test-command`   | Overwrite the default integration test command                                                                                                                                                                  | ❌        | `'npm run test:integration'` |
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   extra-tests:
     description: 'Add an additional command to run before the built-in tests'
     default: 'false'
+  unit-test-check-pattern:
+    description: 'The pattern to check for existence of the unit test command'
+    default: 'test:unit'
   unit-test-command:
     description: 'Overwrite the default unit test command'
     default: 'npm run test:unit'
@@ -71,7 +74,7 @@ runs:
     - name: Run unit tests
       shell: bash
       run: |
-        if npm run | grep -q "test:unit" ; then
+        if npm run | grep -q "${{ inputs.unit-test-check-pattern }}" ; then
           echo "Unit test script found"
           ${{ inputs.unit-test-command }}
         else

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'ioBroker Testing: Adapter tests'
 author: 'AlCalzone'
-#description: 'Greet someone'
+description: 'Run optional unit tests and adapter integration tests'
 
 inputs:
   node-version:
@@ -18,12 +18,18 @@ inputs:
   build:
     description: 'Set to true when the adapter needs a build step before testing'
     default: 'false'
-  build-command: 
+  build-command:
     description: 'Overwrite the default build command'
     default: 'npm run build'
   extra-tests:
     description: 'Add an additional command to run before the built-in tests'
     default: 'false'
+  unit-test-command:
+    description: 'Overwrite the default unit test command'
+    default: 'npm run test:unit'
+  integration-test-command:
+    description: 'Overwrite the default integration test command'
+    default: 'npm run test:integration'
 
 # Conditional syntax isn't supported, but there are workarounds:
 # https://github.com/actions/runner/issues/834#issuecomment-909921245
@@ -32,10 +38,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ (inputs.package-cache != 'false' && inputs.package-cache != '') && inputs.package-cache || '' }}
@@ -67,13 +73,13 @@ runs:
       run: |
         if npm run | grep -q "test:unit" ; then
           echo "Unit test script found"
-          npm run test:unit
+          ${{ inputs.unit-test-command }}
         else
           echo "No unit tests defined, skipping..."
         fi
 
     - name: Run integration tests
       shell: bash
-      run: npm run test:integration
+      run: ${{ inputs.integration-test-command }}
       env:
         DEBUG: 'testing:*'


### PR DESCRIPTION
I have forked this repo to get rid of the warnings in my iobroker adapter workflow actions regarding the usage of the outdated `actions/checkout@v3` and `actions/setup-node@v3`.
The additional `unit-test-command` and `integration-test-command` parameters might not be necessary, but I saw no reason to not overwrite them with the appropriate yarn calls...

Maybe you want to add the parameters and foreign actions update in your official implementation as well. 🤷‍♂️ 