### PR TITLE
add --engine-strict option to npm ci default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   install-command:
     description: "Overwrite the default install command"
-    default: "npm ci"
+    default: "npm ci --engine-strict"
   package-cache:
     description: "Define which package manager to use for dependency caching. Set to 'false' to disable caching."
     default: 'npm'


### PR DESCRIPTION
Tests should fail if some dependencies do not match the engine used for testing, i.e. xyz required node 20 but tests are run at node 18. This can be detected by using --engine-strict option at npm install / npm ci.

This PR add --engine-strict option to the default install command 'npm ci'.  This solve issues #8 and #9 partly.
If useres really want to ignore this test (I have no idea why) the can use a custom install command.

Currently I do not see a upward compatible solution for custom installs (typically 'npm install') so I suggest to keep at least one isseu open to collect further ideas.